### PR TITLE
fix: add .datadogignore to exclude go.sum false positives

### DIFF
--- a/.datadogignore
+++ b/.datadogignore
@@ -1,0 +1,2 @@
+# Ignore go.sum files - false positives (Go module checksums, not secrets)
+**/go.sum


### PR DESCRIPTION
Datadog scanner incorrectly identifies Go module checksums in go.sum files as Azure Shared Access Signature tokens. These are false positives.

Fixes 6 findings in test/src/go.sum (lines 42-47).

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
